### PR TITLE
Fix the assignment of the anonymous userids to the trip data table

### DIFF
--- a/R/utils_query_database.R
+++ b/R/utils_query_database.R
@@ -81,7 +81,7 @@ normalise_uuid <- function(.data, keep_uuid = FALSE) {
 
 #' Anonymize user_id field
 #'
-#' @param .data a data.frame/data.table object
+#' @param .data a data.frame object
 #'
 #' @return .data with anonymized user_id
 #' @export 
@@ -92,10 +92,8 @@ anonymize_uuid <- function(.data) {
   }
   unique_uuid <- unique(.data$user_id)
   anon_uuid <- paste0("user_", sample(length(unique_uuid)))
-  for(i in seq_along(unique_uuid)) {
-    .data$user_id[.data$user_id == unique_uuid[i]] <- anon_uuid[i]
-    # message(unique_uuid[i], anon_uuid[i])
-  }
+  names(anon_uuid) <- unique_uuid
+  .data$user_id <- anon_uuid[.data$user_id]
   .data
 }
 

--- a/R/utils_query_database.R
+++ b/R/utils_query_database.R
@@ -92,7 +92,10 @@ anonymize_uuid <- function(.data) {
   }
   unique_uuid <- unique(.data$user_id)
   anon_uuid <- paste0("user_", sample(length(unique_uuid)))
-  .data$user_id = anon_uuid
+  for(i in seq_along(unique_uuid)) {
+    .data$user_id[.data$user_id == unique_uuid[i]] <- anon_uuid[i]
+    # message(unique_uuid[i], anon_uuid[i])
+  }
   .data
 }
 

--- a/man/anonymize_uuid.Rd
+++ b/man/anonymize_uuid.Rd
@@ -7,7 +7,7 @@
 anonymize_uuid(.data)
 }
 \arguments{
-\item{.data}{a data.frame/data.table object}
+\item{.data}{a data.frame object}
 }
 \value{
 .data with anonymized user_id


### PR DESCRIPTION
https://github.com/asiripanich/emdash/pull/11/commits/d2bd57bdc6b9e9fe210cf8a359602043cea3b95c
won't work because the trips table may have 200 entries from only 5 users.
We need to map each uuid to the corresponding anon uuid.

If you don't do that, you get the error

```
Warning: Error in [[<-.data.frame: replacement has 5 rows, data has 12
```

like I just did 😄

If you can think of a better way of doing this that is not a for loop, that would be great, but let's get it working for now.