### PR TITLE
Fixes to the recent pr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: emdash
 Title: e-mission dashboard built with the Shiny framework
-Version: 1.1.0
+Version: 1.2.0
 Authors@R: person('Amarin', 'Siripanich', email = 'amarin.siri@gmail.com', role = c('cre', 'aut'))
 Description: e-mission dashboard built with the Shiny framework
 License: MIT + file LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN Rscript -e 'remotes::install_version("DT",upgrade="never", version = "0.14")
 RUN Rscript -e 'remotes::install_version("flexdashboard",upgrade="never", version = "0.5.2")'
 RUN Rscript -e 'remotes::install_version("esquisse",upgrade="never", version = "0.3.0")'
 RUN Rscript -e 'remotes::install_version("lubridate",upgrade="never", version = "1.7.8")'
-RUN Rscript -e 'remotes::install_version("dplyr",upgrade="never", version = "0.8.5")'
+RUN Rscript -e 'remotes::install_version("dplyr",upgrade="never", version = "1.0.2")'
 RUN Rscript -e 'remotes::install_version("leaflet",upgrade="never", version = "2.0.3")'
 RUN Rscript -e 'remotes::install_version("janitor",upgrade="never", version = "2.0.1")'
 RUN Rscript -e 'remotes::install_version("tidyr",upgrade="never", version = "1.1.0")'
@@ -30,4 +30,5 @@ ADD . /build_zone
 WORKDIR /build_zone
 RUN R -e 'remotes::install_local(upgrade="never")'
 EXPOSE 80
+
 CMD R -e "options('shiny.port'=80,shiny.host='0.0.0.0');emdash::run_app(mongo_url = 'mongodb://host.docker.internal:27017')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,6 @@ WORKDIR /build_zone
 RUN R -e 'remotes::install_local(upgrade="never")'
 EXPOSE 80
 
-CMD R -e "options('shiny.port'=80,shiny.host='0.0.0.0');emdash::run_app(mongo_url = 'mongodb://host.docker.internal:27017')"
+ENV MONGO_URL=${MONGO_URL:-"mongodb://host.docker.internal:27017"}
+ENV ANON_LOCATIONS=${ANON_LOCATIONS:-FALSE}
+CMD R -e "options('shiny.port'=80,shiny.host='0.0.0.0');emdash::run_app(mongo_url = '$MONGO_URL', anon_locations=$ANON_LOCATIONS)"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# emdash 1.2.0
+
+- Fixed [#15](https://github.com/asiripanich/emdash/issues/15).
+- Fixed the issue with trips didn't show when loading the map without adjusting any of the filter options.
+
 # emdash 1.1.0
 
 ## Major changes

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -149,7 +149,7 @@ app_server <- function( input, output, session ) {
       id = "filtering",
       data_table = reactive(anonymize_uuid_if_required(data_r$trips_with_trajectories)),
       data_name = reactive("data"),
-      data_vars = reactive(cols_to_include_in_map_filter()), # the map filter uses start_fmt_time and end_fmt_time (UTC time)
+      data_vars = cols_to_include_in_map_filter, # the map filter uses start_fmt_time and end_fmt_time (UTC time)
       drop_ids = FALSE
     )
   

--- a/R/utils_tidy_data.R
+++ b/R/utils_tidy_data.R
@@ -204,7 +204,7 @@ generate_trajectories = function(tidied_trips, tidied_locations, project_crs = 4
   # join locations to trips according to time interval overlap (all done in UTC time for consistency)
   data.table::setkey(tidied_locations, user_id, fmt_time_utc, fmt_time_utc_end)
   data.table::setkey(tidied_trips, user_id, start_fmt_time, end_fmt_time)
-  joined_trips_and_locs <- data.table::foverlaps(tidied_locations, tidied_trips)
+  joined_trips_and_locs <- data.table::foverlaps(tidied_locations, tidied_trips, nomatch=NULL)
   
   # convert locations to points
   trajectories <- joined_trips_and_locs %>%

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,6 +60,8 @@ install.packages("remotes")
 remotes::install_github("asiripanich/emdash")
 ```
 
+Alternatively, with Docker `docker pull amarins/emdash`.
+
 ## How to use the dashboard
 
 ### Run locally 
@@ -111,7 +113,7 @@ For convenience, you may use this `docker_start_test_mongodb.sh` for starting up
 
 We provide a Dockerfile to run this dashboard. In the future we may include this as part of an e-mission docker-compose file which will be hosted on [the e-mission-docker github repo](https://github.com/e-mission/e-mission-docker).
 
-Be warned that the emdash Docker image is quite large, around 2.8 GB, and take a while to build.
+Be warned that the emdash Docker image is quite large, around 2.8 GB, and take a while to build. You can use pull from [the emdash docker repository](https://hub.docker.com/r/amarins/emdash) and skip the wait!
 
 ## How to customise the dashboard
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ install.packages("remotes")
 remotes::install_github("asiripanich/emdash")
 ```
 
+Alternatively, with Docker `docker pull amarins/emdash`.
+
 ## How to use the dashboard
 
 ### Run locally
@@ -113,7 +115,8 @@ hosted on [the e-mission-docker github
 repo](https://github.com/e-mission/e-mission-docker).
 
 Be warned that the emdash Docker image is quite large, around 2.8 GB,
-and take a while to build.
+and take a while to build. You can use pull from [the emdash docker
+repository](https://hub.docker.com/r/amarins/emdash) and skip the wait\!
 
 ## How to customise the dashboard
 


### PR DESCRIPTION
Two fixes:
- Bump up the dplyr version because otherwise the code fails
- Have the input options set using environment variables so that it is easier to include in a docker-compose
  - We can also then publish an image

@asiripanich any thoughts on publishing an image? It takes so long to build the image, that I think it would be useful to publish an image on dockerhub that at least includes all the R dependencies.

Users can then pass in environment variables, customize the Dockerfile further, or mount a volume to run from locally checked out source.

Do you want to publish the image or should I?