### PR TITLE
Remove the removal of the user email

### DIFF
--- a/R/utils_tidy_data.R
+++ b/R/utils_tidy_data.R
@@ -22,8 +22,7 @@ tidy_participants <- function(stage_profiles, stage_uuids) {
   # print(cols_to_purge)
   merged %>%
     .[, eval(cols_to_purge) := NULL] %>%
-    data.table::setcolorder(c("user_email", "user_id")) %>%
-    .[, -"user_email"]
+    data.table::setcolorder(c("user_email", "user_id"))
 }
 
 #' Tidy the 'cleaned trips' data.frame into a sf object.


### PR DESCRIPTION
So that it is displayed, and program administrators can map tokens to end users


Testing done:
https://github.com/asiripanich/emdash/issues/36#issuecomment-855180598