### PR TITLE
Add some addition fields to ignore

### DIFF
--- a/inst/config-default.yml
+++ b/inst/config-default.yml
@@ -26,6 +26,7 @@ default:
   - distance
   - geometry
   - source
+  - cleaned_trip
 
  cols_to_remove_from_map_popup:
   - start_fmt_time0
@@ -39,6 +40,8 @@ default:
   - duration
   - distance
   - location_points
+  - source
+  - cleaned_trip
   
   
  # Set the labels to display for the participant data 


### PR DESCRIPTION
Notably, after switching to displaying confirmed trips in
https://github.com/asiripanich/emdash/pull/23
the trips dataframe will have a `cleaned_trip` that shouldn't be displayed.

Also, the source (time filter v/s distance filter) is also not something we
need to display