### PR TITLE
Fix minor issue with filtering trip table entries using the config.yml

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -131,7 +131,7 @@ app_server <- function(input, output, session) {
     )
     callModule(mod_DT_server, "DT_ui_trips",
       data = data_r$trips %>%
-        dplyr::select(-dplyr::any_of(getOption("emdash.cols_to_remove_trips_table"))) %>%
+        dplyr::select(-dplyr::any_of(getOption("emdash.cols_to_remove_from_trips_table"))) %>%
         sf::st_drop_geometry()
     )
   })


### PR DESCRIPTION
The config file has `emdash_cols_to_remove_from_trips_table`
https://github.com/asiripanich/emdash/blob/38438d663242372d8aac5a3455b6d7ff690ab57a/R/run_app.R#L31

The code **had**  `emdash.cols_to_remove_trips_table`
https://github.com/asiripanich/emdash/blob/a0ff2f43bd800dec55fd30adf2e9c23a8fa8ee8c/R/app_server.R#L134

Fixed to `emdash.cols_to_remove_from_trips_table`

Testing done:
- Before the change, had a bunch of extraneous columns
- After the change, do not have them any more