### PR TITLE
- Fix the mismatch between the colors on the map and the legend. Unfo…

### DIFF
--- a/R/mod_mapview.R
+++ b/R/mod_mapview.R
@@ -25,7 +25,6 @@ mod_mapview_server <- function(input, output, session, data_sf, mapview.map.type
   req(data_sf)
 
   data_r <- reactiveValues(data = data_sf)
-
   output$map <- leaflet::renderLeaflet({
     if (nrow(data_sf) == 0) {
       m <- mapview::mapview(map.types = mapview.map.types)
@@ -34,7 +33,6 @@ mod_mapview_server <- function(input, output, session, data_sf, mapview.map.type
         mapview::mapview(
           data_sf,
           zcol = getOption('emdash.map_trajectory_colors_variable'),
-          color = randomcoloR::distinctColorPalette,
           map.types = mapview.map.types
         )
     }


### PR DESCRIPTION
…rtunately, this is a quick fix only, by going back to using the mapview's default palatte, which seems to be the only option that works. (#56)