### PR TITLE
Specify trip columns by inclusion

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -103,6 +103,7 @@ app_server <- function(input, output, session) {
     if (!is.null(data_geogr$trips) && input$tabs == "trips") {
       data_esquisse$data <-
         data_geogr$trips %>%
+        dplyr::select(dplyr::any_of(getOption('emdash.cols_to_include_in_trips_table'))) %>%  # select the columns we want
         drop_list_columns() %>%
         sf::st_drop_geometry()
     }
@@ -279,7 +280,8 @@ app_server <- function(input, output, session) {
   observeEvent(data_geogr$click, {
     callModule(mod_DT_server, "DT_ui_trips",
       data = data_geogr$trips %>%
-        dplyr::select(-dplyr::any_of(getOption("emdash.cols_to_remove_from_trips_table"))) %>%
+        dplyr::select(dplyr::any_of(getOption('emdash.cols_to_include_in_trips_table'))) %>% 
+        #dplyr::select(-dplyr::any_of(getOption("emdash.cols_to_remove_from_trips_table"))) %>%
         sf::st_drop_geometry()
     )
   })

--- a/inst/config-default.yml
+++ b/inst/config-default.yml
@@ -26,6 +26,29 @@ default:
  # In col_labels_for_participts, "unconfirmed" gets set to "unlabeled"
  confirmed_user_input_column: data.user_input.mode_confirm
  
+ ## Specify columns to include in the trips table:
+ # Use 'trips_table_merge_user_email' and list it here to include user_email
+ cols_to_include_in_trips_table:
+  - user_id
+  - user_email     # if this is merged with trips, it will appear. Otherwise it is ignored
+  - start_local_time
+  - end_local_time
+  - mode_confirm
+  - purpose_confirm
+  - replaced_mode
+  - duration_min
+  - distance_mi
+  - distance_km
+  
+# Current set of possible trip columns from Stage_analysis_timeseries:
+# c("user_id", "start_fmt_time0", "start_local_dt_timezone", "start_fmt_time", 
+# "start_local_time", "end_fmt_time0", "end_local_dt_timezone", 
+# "end_fmt_time", "end_local_time", "source", "end_loc_coordinates", 
+# "start_loc_coordinates", "duration", "distance", "cleaned_trip", 
+# "inferred_labels", "inferred_trip", "expectation_to_label", "expected_trip", 
+# "mode_confirm", "purpose_confirm", "replaced_mode", "geometry", 
+# "duration_min", "distance_mi", "distance_km")
+ 
  ## Specify columns to exclude from various tables:
  # participants
  cols_to_remove_from_participts_table:


### PR DESCRIPTION
- added cols_to_include_in_trips_table to config-defualt.yml
- used dplyr:: select and any_of to select those columns before displaying for the interactive plot and for the table

In future changes, might want to unlist inferred labels somehow.