### PR TITLE
Turn off pagination so that csv and excel exports work

### DIFF
--- a/R/mod_DT.R
+++ b/R/mod_DT.R
@@ -29,6 +29,7 @@ mod_DT_server <- function(input, output, session, data, DT_options) {
       scrollX = TRUE,
       pageLength = 50,
       dom = "Bfrtip",
+      bPaginate = FALSE,
       buttons = c("copy", "csv", "excel", "pdf", "print", "colvis")
     )
   }


### PR DESCRIPTION
Since we are selecting subsets of trips on the server anyway, we don't need to
re-paginate in the data table. This also allows csv and excel exports to work properly.